### PR TITLE
Update data.json

### DIFF
--- a/fixtures/api/coupon/data.json
+++ b/fixtures/api/coupon/data.json
@@ -19,7 +19,7 @@
         {
             "name": "discountType",
             "description": {
-                "en": "Discount type. Possible values: PERCENT, FIX."
+                "en": "Discount type. Possible values: PERCENT, FIXED."
             },
             "required": false,
             "readonly": false


### PR DESCRIPTION
There is an error in the documentation. The discountType of a coupon should be  "PERCENT" or "FIXED", not "FIX"

Fix for https://github.com/Shoprenter/sr-api-docs/issues/80